### PR TITLE
chore(deps): bump apis-core to v0.7.1, drop override-select2js

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,9 @@ python = "^3.11"
 django = ">=4.1,<4.2"
 django-allow-cidr = "^0.6.0"
 psycopg2 = "^2.9"
-apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.7.0"}
+apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.7.1"}
 apis-highlighter-ng = { git = "https://github.com/acdh-oeaw/apis-highlighter-ng.git"}
 apis-acdhch-default-settings = { git = "https://github.com/acdh-oeaw/apis-acdhch-default-settings.git", tag = "v0.1.7" }
-apis-override-select2js = { git="https://github.com/acdh-oeaw/apis-override-select2js", tag="v0.1.0" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
override-select2js is a dependecy of apis-core since v0.6.3
