### PR TITLE
chore(deps): drop django dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ packages = [{include = "apis_ontology"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-django = ">=4.1,<4.2"
 django-allow-cidr = "^0.6.0"
 psycopg2 = "^2.9"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.7.1"}


### PR DESCRIPTION
Django is already a dependency of apis-core, therefore we don't have to
list it separately
