### PR TITLE
fix: readd admin

### DIFF
--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,3 +1,4 @@
+from django.contrib import admin
 from django.urls import include
 from django.urls import path
 from django.views.generic import TemplateView
@@ -6,6 +7,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from apis_core.apis_entities.api_views import GetEntityGeneric
 
 urlpatterns = [
+    path("admin/", admin.site.urls),
     path("apis/", include("apis_core.urls", namespace="apis")),
     path("accounts/", include("django.contrib.auth.urls")),
     path(


### PR DESCRIPTION
apparently the endpoint configured for `apis/admin` does not work
