### PR TITLE
fix: override FormHelper from GenericModelForm

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -1,6 +1,7 @@
 from django.forms import CharField, Textarea
 from apis_ontology.models import Institution, Text, Event, Person, Place, Work
 from crispy_forms.layout import Layout, HTML
+from crispy_forms.helper import FormHelper
 from apis_core.generic.forms import GenericModelForm
 
 
@@ -20,6 +21,8 @@ class EntityForm(GenericModelForm):
             text_details.append(ttype)
         text_details.append(HTML("</details>"))
 
+        self.helper = FormHelper()
+        self.helper.form_tag = False
         all_other_fields = [f for f in self.fields if f not in text_details]
         self.helper.layout = Layout(*all_other_fields, text_details)
 


### PR DESCRIPTION
the GenericModelForm creates the whole form, but the legacy template
also makes a form - so we override the FormHelper for now, until the
template is fixed
