### PR TITLE
feat: implement place autocomplete and import

### DIFF
--- a/apis_ontology/importers.py
+++ b/apis_ontology/importers.py
@@ -2,6 +2,12 @@ from apis_core.generic.importers import GenericImporter
 from apis_core.utils.rdf import get_definition_and_attributes_from_uri
 
 
+class PlaceImporter(GenericImporter):
+    def request(self, uri):
+        model, data = get_definition_and_attributes_from_uri(uri)
+        return data
+
+
 class PersonImporter(GenericImporter):
 
     def request(self, uri):

--- a/apis_ontology/querysets.py
+++ b/apis_ontology/querysets.py
@@ -11,7 +11,23 @@ DB_COLLATION = 'binary' if 'sqlite' in settings.DATABASES['default']['ENGINE'] e
 PersonListViewQueryset = Person.objects.all().order_by(Collate("name", DB_COLLATION), Collate("first_name", DB_COLLATION))
 
 
-class PersonExternalAutocomplete:
+class TypeSense_ExternalAutocomplete:
+    def get_results(self, q):
+        typesensetoken = os.getenv("TYPESENSE_TOKEN", None)
+        typesenseserver = os.getenv("TYPESENSE_SERVER", None)
+        if typesensetoken and typesenseserver and getattr(self, "collectionname"):
+            url = f"{typesenseserver}/collections/{self.collectionname}/documents/search?q={q}&query_by=description&query_by=label"
+            req = urllib.request.Request(url)
+            req.add_header("X-TYPESENSE-API-KEY", typesensetoken)
+            with urllib.request.urlopen(req) as f:
+                data = json.loads(f.read())
+                results = list(map(self.extract, data.get("hits", [])))
+                return results
+        return {}
+
+
+class PlaceExternalAutocomplete(TypeSense_ExternalAutocomplete):
+    collectionname = "prosnet-wikidata-place-index"
 
     def extract(self, res):
         url = res["document"]["id"]
@@ -26,16 +42,19 @@ class PersonExternalAutocomplete:
             "selected_text": label,
         }
 
-    def get_results(self, q):
-        collectionname = "prosnet-wikidata-person-index"
-        typesensetoken = os.getenv("TYPESENSE_TOKEN", None)
-        typesenseserver = os.getenv("TYPESENSE_SERVER", None)
-        if typesensetoken and typesenseserver:
-            url = f"{typesenseserver}/collections/{collectionname}/documents/search?q={q}&query_by=description&query_by=label"
-            req = urllib.request.Request(url)
-            req.add_header("X-TYPESENSE-API-KEY", typesensetoken)
-            with urllib.request.urlopen(req) as f:
-                data = json.loads(f.read())
-                results = list(map(self.extract, data.get("hits", [])))
-                return results
-        return {}
+
+class PersonExternalAutocomplete(TypeSense_ExternalAutocomplete):
+    collectionname = "prosnet-wikidata-person-index"
+
+    def extract(self, res):
+        url = res["document"]["id"]
+        label = res["document"]["label"]
+        if highlight := res.get("highlight"):
+            if isinstance(highlight.get("label", {}), dict):
+                label = highlight.get("label", {}).get("snippet", "")
+        label += f' <a href="{url}">{url}</a>'
+        return {
+            "id": url,
+            "text": label,
+            "selected_text": label,
+        }

--- a/apis_ontology/rdfimport/PlaceFromWikidata.toml
+++ b/apis_ontology/rdfimport/PlaceFromWikidata.toml
@@ -1,0 +1,45 @@
+##############################################
+# Create an entity `apis_ontology.Person`
+# from a wikidata RDF endpoint
+##############################################
+model = "apis_ontology.Place"
+filter_sparql = """
+PREFIX ps: <http://www.wikidata.org/prop/statement/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+ASK {
+  ?subject wdt:P279* wd:Q123964505.
+}
+"""
+[[attributes]]
+# name
+sparql = """
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX schema: <http://schema.org/>
+SELECT ?name
+WHERE {
+  ?something schema:about ?subject .
+  ?subject rdfs:label ?label .
+  OPTIONAL { ?subject wdt:P1448/rdfs:label ?official_label }
+  BIND(COALESCE(?official_label, ?label) AS ?name)
+}
+"""
+[[attributes]]
+# lng
+sparql = '''
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?lng
+WHERE {
+  ?subject wdt:P625 ?geo1 .
+  BIND(REPLACE(str(?geo1), "Point\\((\\d+\\.\\d+).*$", "$1") as ?lng)
+  }
+'''
+[[attributes]]
+# lat
+sparql = '''
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?lat
+WHERE {
+  ?subject wdt:P625 ?geo1 .
+  BIND(REPLACE(str(?geo1), "Point\\((\\d+\\.\\d+) (\\d+\\.\\d+).*$", "$2") as ?lat)
+  }
+'''


### PR DESCRIPTION
This refactors the typesense autocomplete stuff out and then adds a
`apis_ontology.querysets.PlaceExternalAutocomplete`, which inherits from
the typesense class.
It also adds a PlaceImporter and a RDF config file for places from
wikidata.
