### PR TITLE
fix(template): drop login block override

### DIFF
--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -1,35 +1,5 @@
 {% extends "base.html" %}
 
-{% block userlogin-menu %}
-<ul class="navbar-nav">
-  {% if user.is_authenticated %}
-    <li class="nav-item dropdown ml-auto">
-      <a href=""
-         class="nav-link dropdown-toggle"
-         data-toggle="dropdown"
-         role="button"
-         aria-haspopup="true"
-         aria-expanded="false">User: {{ user.get_username }}</a>
-      <div class="dropdown-menu dropdown-menu-right">
-        <div class="dropdown-item">
-          <a class="nav-link p-0" href="{% url 'apis:logout' %}?next=/">
-            <span class="material-symbols-outlined">logout</span>
-            log out
-          </a>
-        </div>
-      </div>
-    </li>
-  {% else %}
-    <li class="nav-item dropdown ml-auto">
-      <a class="nav-link p-0"
-         href="{% url 'apis:login' %}?next={{ request.path|urlencode }}">
-        <span class="material-symbols-outlined">login</span>
-      </a>
-    </li>
-  {% endif %}
-</ul>
-{% endblock userlogin-menu %}
-
 {% block imprint %}
   <div id="wrapper-footer-secondary"
        class="footer-imprint-bar p-2 text-center">


### PR DESCRIPTION
We only used that override for adding a `logging` menu item, which we
currently disabled for the time of the import.
