### PR TITLE
chore(deps): bump apis-core to v0.23.0

### DIFF
--- a/apis_ontology/importers.py
+++ b/apis_ontology/importers.py
@@ -1,23 +1,8 @@
-from apis_core.generic.importers import GenericImporter
-from apis_core.utils.rdf import get_definition_and_attributes_from_uri
-from apis_ontology.models import Person, Place, Institution
+from apis_core.generic.importers import GenericModelImporter
 
 
-class PlaceImporter(GenericImporter):
-    def request(self, uri):
-        model, data = get_definition_and_attributes_from_uri(uri, Place)
-        return data
-
-
-class PersonImporter(GenericImporter):
-    def request(self, uri):
-        model, data = get_definition_and_attributes_from_uri(uri, Person)
+class PersonImporter(GenericModelImporter):
+    def mangle_data(self, data):
         if "profession" in data:
             del data["profession"]
-        return data
-
-
-class InstitutionImporter(GenericImporter):
-    def request(self, uri):
-        model, data = get_definition_and_attributes_from_uri(uri, Institution)
         return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "apis_ontology"}]
 [tool.poetry.dependencies]
 python = "^3.11"
 psycopg2 = "^2.9"
-apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.22.0"}
+apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.23.0"}
 apis-highlighter-ng = "^0.4.0"
 apis-acdhch-default-settings = "1.0.0"
 django-action-logger = "^0.1.5"


### PR DESCRIPTION
The `GenericImporter` from apis-core was renamed to
`GenericModelImporter` and is thus picked automatically for all the
models inheriting from `GenericModel`. This means we don't have to
override it, if we don't want to change its functionality. It now also
automatically tries to import using RDF, therefore we can drop our
overrides for Place and Institution. For Person we still override the
importer, to be able to mangle that data before import, but at least the
inheriting `PersonImporter` now gets a bit smaller.