### PR TITLE
feat(deps): add django-auditlog

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -12,6 +12,8 @@ from apis_core.apis_entities.abc import E53_Place
 from apis_core.history.models import VersionMixin
 from apis_core.utils.fields import NewlineSeparatedListField
 
+from auditlog.registry import auditlog
+
 
 class LegacyStuffMixin(models.Model):
     sources = GenericRelation("Source")
@@ -230,3 +232,16 @@ class Denomination(AbstractEntity):
     class Meta:
         verbose_name = _("Denomination")
         verbose_name_plural = _("Denominations")
+
+
+auditlog.register(Source, serialize_data=True)
+auditlog.register(Title, serialize_data=True)
+auditlog.register(ProfessionCategory, serialize_data=True)
+auditlog.register(Profession, serialize_data=True)
+auditlog.register(Parentprofession, serialize_data=True)
+auditlog.register(Event, serialize_data=True)
+auditlog.register(Institution, serialize_data=True)
+auditlog.register(Person, serialize_data=True, m2m_fields={"profession", "title", "profession_mother", "profession_mother"})
+auditlog.register(Place, serialize_data=True)
+auditlog.register(Work, serialize_data=True)
+auditlog.register(Denomination, serialize_data=True)

--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -6,6 +6,7 @@ INSTALLED_APPS += ["apis_highlighter", "django.contrib.postgres", "apis_core.col
 INSTALLED_APPS.remove("apis_ontology")
 INSTALLED_APPS.insert(0, "apis_ontology")
 INSTALLED_APPS += ["django_acdhch_functions"]
+INSTALLED_APPS += ["auditlog"]
 
 ROOT_URLCONF = 'apis_ontology.urls'
 
@@ -40,3 +41,5 @@ LOGGING = {
 LOG_LIST_NOSTAFF_EXCLUDE_APP_LABELS = ["reversion", "admin", "sessions", "auth"]
 
 LANGUAGE_CODE = "de"
+
+MIDDLEWARE += ['auditlog.middleware.AuditlogMiddleware']

--- a/apis_ontology/templates/auditlog/logentry_list.html
+++ b/apis_ontology/templates/auditlog/logentry_list.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+{% if object_list %}
+<ul>
+  {% for object in object_list %}
+    <li>{{ object.timestamp }} <a href={% url "apis_core:generic:detail" object.content_type object.object_id %}>{{ object }}</a>
+    {% if object.action != 2 %}:
+      {% for change, values in object.changes_dict.items %}<b>{{ change }}</b>
+        {% if values.operation and values.objects %}
+          {{ values.operation }} {{ values.objects|join:", " }}
+        {% else %}
+          "{{ values.0|truncatechars:32 }}" -> "{{ values.1|truncatechars:32 }}"
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+</div>
+{% endblock content %}

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -5,6 +5,8 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from apis_core.apis_entities.api_views import GetEntityGeneric
 
+from apis_ontology.views import UserAuditLog
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -21,3 +23,4 @@ urlpatterns = [
 urlpatterns += staticfiles_urlpatterns()
 #urlpatterns += [path("logger/", include("django_action_logger.urls")),]
 urlpatterns += [path("", include("django_acdhch_functions.urls")),]
+urlpatterns += [path("auditlog", UserAuditLog.as_view()),]

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -1,0 +1,8 @@
+from django.views.generic.list import ListView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from auditlog.models import LogEntry
+
+
+class UserAuditLog(LoginRequiredMixin, ListView):
+    def get_queryset(self, *args, **kwargs):
+        return LogEntry.objects.filter(actor=self.request.user)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.23.0"
 apis-highlighter-ng = "^0.4.0"
 apis-acdhch-default-settings = "1.0.0"
 django-acdhch-functions = "^0.1.3"
+django-auditlog = "^3.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This adds the django auditlog module and enables it for our ontology
models. It also adds the middleware, so that we have access to the
actor.
We also create an endpoint `/auditlog` that lists the changes made by
the user requesting it.
